### PR TITLE
Minor fixes

### DIFF
--- a/grammar/GlslLexer.flex
+++ b/grammar/GlslLexer.flex
@@ -99,6 +99,8 @@ INCLUDE_PATH={IDENTIFIER}([\s\/]*{IDENTIFIER}\s*)*(\.{IDENTIFIER})?
 
 <MACRO_IDENTIFIER_STATE> {
   {WHITE_SPACE}                    { return WHITE_SPACE; }
+  {BACKSLASH}                      { return WHITE_SPACE; }
+  {NEW_LINE}                       { yybegin(YYINITIAL); return PP_END; }
   {IDENTIFIER}                     { return IDENTIFIER; }
 }
 

--- a/src/main/kotlin/glsl/plugin/psi/named/types/user/GlslNamedBlockStructure.kt
+++ b/src/main/kotlin/glsl/plugin/psi/named/types/user/GlslNamedBlockStructure.kt
@@ -54,7 +54,7 @@ abstract class GlslNamedBlockStructure(node: ASTNode) : GlslNamedTypeImpl(node),
      *
      */
     override fun getLookupElement(returnTypeText: String?): LookupElement? {
-        TODO("Not yet implemented")
+        return null // TODO
     }
 
     /**

--- a/src/test/kotlin/GlslFormatterTest.kt
+++ b/src/test/kotlin/GlslFormatterTest.kt
@@ -10,11 +10,11 @@ class GlslFormatterTest : BasePlatformTestCase() {
     }
 
     fun testFormatter() {
-        myFixture.configureByFile("FormatterFile.glsl")
+        myFixture.configureByFile("formatterFile.glsl")
         WriteCommandAction.writeCommandAction(project).run<RuntimeException> {
             val codeStyleManager = CodeStyleManager.getInstance(project)
             codeStyleManager.reformatText(myFixture.file, listOf(myFixture.file.textRange))
         }
-        myFixture.checkResultByFile("FormatterFileExpected.glsl")
+        myFixture.checkResultByFile("formatterFileExpected.glsl")
     }
 }


### PR DESCRIPTION
- Fixed tests failing on linux
- Fixed MACRO_IDENTIFIER_STATE lexer state leaking across newline
- Fixed a crash caused by getLookupElement calling kotlin TODO instead of returning null

Supersedes #47 (part 1 of 4)