### PR TITLE
remove default value of `untilBuild`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ patchPluginXml {
     changeNotes = changelog.get(version.toString()).toHTML()
     pluginDescription = descriptionHtml
     sinceBuild = '223'
+    untilBuild.set(provider { null })
 }
 
 changelog {


### PR DESCRIPTION
You recently [tried to remove the upper bound on the compatible IDE version](https://github.com/rmordechay/glsl-plugin-idea/commit/6eb266a7520b7f53bb7954ea3651fd0635159ac0#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L80), but according to [the documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html#intellijPlatform-pluginConfiguration-ideaVersion-untilBuild), it will default to the latest major version based on the currently selected IntelliJ Platform. This PR removes that default behavior.

Fixes #55, #56