### PR TITLE
Prevent invalid PSI access during project disposal (intellij 2025.3)

### DIFF
--- a/src/main/kotlin/glsl/plugin/editor/highlighting/GlslHighlightingAnnotator.kt
+++ b/src/main/kotlin/glsl/plugin/editor/highlighting/GlslHighlightingAnnotator.kt
@@ -23,6 +23,10 @@ class GlslHighlightingAnnotator : Annotator {
      *
      */
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        val project = element.project
+        if (project.isDisposed) return
+        if (!element.isValid) return
+
         if (element !is GlslIdentifier || element is GlslBuiltinType) return
         val extension = holder.currentAnnotationSession.file.virtualFile.extension
         val elementName = element.getName()

--- a/src/main/kotlin/glsl/plugin/editor/style/GlslCodeStyleProvider.kt
+++ b/src/main/kotlin/glsl/plugin/editor/style/GlslCodeStyleProvider.kt
@@ -3,6 +3,7 @@ package glsl.plugin.editor.style
 import com.intellij.application.options.CodeStyleAbstractConfigurable
 import com.intellij.application.options.CodeStyleAbstractPanel
 import com.intellij.application.options.TabbedLanguageCodeStylePanel
+import com.intellij.lang.Language
 import com.intellij.psi.codeStyle.CodeStyleConfigurable
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
@@ -13,6 +14,10 @@ import glsl.plugin.language.GlslLanguage
  *
  */
 class GlslCodeStyleProvider : CodeStyleSettingsProvider() {
+
+    override fun getLanguage(): Language? {
+        return GlslLanguage.INSTANCE
+    }
 
     /**
     *

--- a/src/main/kotlin/glsl/plugin/reference/GlslVariableReference.kt
+++ b/src/main/kotlin/glsl/plugin/reference/GlslVariableReference.kt
@@ -1,8 +1,10 @@
 package glsl.plugin.reference
 
 import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiInvalidElementAccessException
 import com.intellij.psi.impl.source.resolve.ResolveCache
 import com.intellij.psi.impl.source.resolve.ResolveCache.AbstractResolver
 import com.intellij.psi.util.PsiTreeUtil.getParentOfType
@@ -25,6 +27,10 @@ class GlslVariableReference(private val element: GlslVariable, textRange: TextRa
     GlslReference(element, textRange) {
 
     private val resolver = AbstractResolver<GlslReference, GlslNamedVariable> { reference, _ ->
+        val project = reference.element.project
+        if (project.isDisposed) return@AbstractResolver null
+        if (!reference.element.isValid) return@AbstractResolver null
+
         reference.doResolve()
         reference.resolvedReferences.firstOrNull() as? GlslNamedVariable
     }
@@ -33,15 +39,28 @@ class GlslVariableReference(private val element: GlslVariable, textRange: TextRa
      *
      */
     override fun resolve(): GlslNamedVariable? {
-        if (!shouldResolve()) return null
-        val resolveCache = ResolveCache.getInstance(project)
-        return resolveCache.resolveWithCaching(this, resolver, true, false)
+        return try {
+            val project = element.project
+            if (project.isDisposed) return null
+            if (!element.isValid) return null
+
+            if (!shouldResolve()) return null
+            val resolveCache = ResolveCache.getInstance(project)
+            return resolveCache.resolveWithCaching(this, resolver, true, false)
+        } catch (e: Throwable) {
+            if (e is ProcessCanceledException) throw e
+            null
+        }
     }
 
     /**
      *
      */
     override fun getVariants(): Array<LookupElement> {
+        val project = element.project
+        if (project.isDisposed) return emptyArray()
+        if (!element.isValid) return emptyArray()
+
         doResolve(CONTAINS)
         return resolvedReferences.mapNotNull { it.getLookupElement() }.toTypedArray()
     }
@@ -50,6 +69,10 @@ class GlslVariableReference(private val element: GlslVariable, textRange: TextRa
      *
      */
     override fun resolveMany(): List<GlslNamedElement> {
+        val project = element.project
+        if (project.isDisposed) return emptyList()
+        if (!element.isValid) return emptyList()
+
         if (!shouldResolve()) return emptyList()
         val resolveCache = ResolveCache.getInstance(project)
         resolveCache.resolveWithCaching(this, resolver, true, false)
@@ -60,6 +83,10 @@ class GlslVariableReference(private val element: GlslVariable, textRange: TextRa
      *
      */
     override fun doResolve(filterType: FilterType) {
+        val project = element.project
+        if (project.isDisposed) return
+        if (!element.isValid) return
+
         try {
             resolvedReferences.clear()
             currentFilterType = filterType
@@ -73,6 +100,8 @@ class GlslVariableReference(private val element: GlslVariable, textRange: TextRa
                 externalDeclaration = getParentOfType(element, GlslExternalDeclaration::class.java)
             }
             lookupInGlobalScope(externalDeclaration)
+        } catch (_: PsiInvalidElementAccessException) {
+            includeFiles.clear()
         } catch (_: StopLookupException) {
             includeFiles.clear()
         }


### PR DESCRIPTION
This PR adds additional defensive guards around PSI resolve paths to fix 
```java
com.intellij.diagnostic.PluginException: Invalid PSI Element: class glsl.psi.impl.GlslStructDeclaratorImpl [Plugin: OpenGL-Plugin]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:100)
	at com.intellij.psi.util.PsiUtilCore.ensureValid(PsiUtilCore.java:509)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolve(ResolveCache.java:229)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:276)
	at glsl.plugin.reference.GlslVariableReference.resolve(GlslVariableReference.kt:38)
	at glsl.plugin.reference.GlslVariableReference.resolve(GlslVariableReference.kt:24)
	at glsl.plugin.psi.GlslIdentifier$DefaultImpls.resolveReference(GlslIdentifier.kt:31)
```

These guards introduce some redundancy but have negligible performance impact, and runtime plugin exception pop up windows are quite disruptive.

I also updated the deprecated API usage
```java
com.intellij.diagnostic.PluginException: Legacy configurable id calculation mode from localizable name will be used for configurable class glsl.plugin.editor.style.GlslCodeStyleProvider. Please override getConfigurableId or getLanguage. [Plugin: OpenGL-Plugin] 
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23) 
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90) 
	at com.intellij.diagnostic.PluginException.logPluginError(PluginException.java:112)
	at com.intellij.psi.codeStyle.CodeStyleSettingsProvider.getConfigurableId(CodeStyleSettingsProvider.java:71)
```
